### PR TITLE
Correction des select avec Svelte > 3.56.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "prettier-plugin-tailwindcss": "0.2.4",
         "remixicon": "2.5.0",
         "showdown": "2.1.0",
-        "svelte": "3.56.0",
+        "svelte": "3.59.2",
         "svelte-check": "3.1.4",
         "svelte-portal": "2.2.0",
         "svgo": "3.0.2",
@@ -6490,9 +6490,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "3.56.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.56.0.tgz",
-      "integrity": "sha512-LvXiJbjdvJKwB/0CQyYpDX0q+hFqCyWmybzC2G6eK1tJJA/RSRCytTfNmjHv+RHlLuA70vWG7nXp6gbeErYvRA==",
+      "version": "3.59.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
+      "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
       "engines": {
         "node": ">= 8"
       }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prettier-plugin-tailwindcss": "0.2.4",
     "remixicon": "2.5.0",
     "showdown": "2.1.0",
-    "svelte": "3.56.0",
+    "svelte": "3.59.2",
     "svelte-check": "3.1.4",
     "svelte-portal": "2.2.0",
     "svgo": "3.0.2",

--- a/src/lib/components/inputs/select/simple-autocomplete.svelte
+++ b/src/lib/components/inputs/select/simple-autocomplete.svelte
@@ -703,12 +703,6 @@
     return regexp;
   }
 
-  // workaround for
-  // ValidationError: 'multiple' attribute cannot be dynamic if select uses two-way binding
-  function multipleAction(node) {
-    node.multiple = multiple;
-  }
-
   function isConfirmed(newValue) {
     if (!value) {
       return false;
@@ -727,7 +721,7 @@
   class:show-clear={clearable}
   class:is-loading={showLoadingIndicator && loading}
 >
-  <select name={selectName} id={selectId} bind:value use:multipleAction>
+  <select name={selectName} id={selectId}>
     {#if !multiple && value}
       <option {value} selected>{text}</option>
     {:else if multiple && value}


### PR DESCRIPTION
https://trello.com/c/aUWThsRh/901-la-mise-%C3%A0-jour-de-svelte-casse-les-select

Le passage à Svelte 3.57.0 cassait plusieurs de nos select; leur onChange était désormais appelé dès l'initialisation avec une valeur nulle.

Le problème a été isolé sur cette ligne:

https://github.com/gip-inclusion/dora-front/blob/a49565a7fa2c44ca8dac8728aa168721fff655fc/src/lib/components/inputs/select/simple-autocomplete.svelte#L730

le `bind` mettait à jour `value`, en changeant sa valeur de `undefined` à `null` ce qui provoquait l'appel de `onValueChanged`

https://github.com/gip-inclusion/dora-front/blob/a49565a7fa2c44ca8dac8728aa168721fff655fc/src/lib/components/inputs/select/simple-autocomplete.svelte#L174


En cherchant une éventuelle solution adoptée dans le code upstream, on voit que ce `bind` n'était de toute façon pas nécessaire

https://github.com/pstanoev/simple-svelte-autocomplete/commit/cd933e00ed69ba57a402e56c8cb7d43ef096e5d5
