### PR TITLE
Restauration des user-data dans l'évènement plausible "service"

### DIFF
--- a/src/lib/utils/plausible.ts
+++ b/src/lib/utils/plausible.ts
@@ -187,7 +187,7 @@ export function trackService(service, url) {
     }
   }
 
-  _track("service", _getServiceProps(service, false));
+  _track("service", _getServiceProps(service, true));
 }
 
 export function trackDIService(service, url) {


### PR DESCRIPTION
https://trello.com/c/6EtZcHSP/918-donn%C3%A9e-plausible-%C3%A0-remettre-en-etat

Aucune idée pourquoi j'ai mis le booléen est passé de `true` à `false` (ça sent clairement le copier-coller foireux 😔)