### PR TITLE
Affichage du téléphone si le prescripteur est le référent

### DIFF
--- a/src/routes/orientations/+page.svelte
+++ b/src/routes/orientations/+page.svelte
@@ -261,6 +261,13 @@
                         link={`/structures/${orientation.prescriberStructure?.slug}`}
                       />
                     {/if}
+
+                    {#if orientation.referentPhone && orientation.referentEmail === orientation.prescriber.email}
+                      <ContactListItem
+                        icon={phoneLineIcon}
+                        text={formatPhoneNumber(orientation.referentPhone)}
+                      />
+                    {/if}
                   </ul>
                 </div>
               </div>


### PR DESCRIPTION
https://trello.com/c/Nb0x4BeU/926-orientation-ajouter-dans-la-demande-dor-sur-dora-le-no-de-tel-du-prescripteur-si-au-r%C3%A9f%C3%A9rent