### PR TITLE
Réparation des warnings a11y de Svelte

### DIFF
--- a/src/lib/components/display/dropdown-menu.svelte
+++ b/src/lib/components/display/dropdown-menu.svelte
@@ -31,6 +31,7 @@
 
 <div
   use:clickOutside
+  role="presentation"
   on:click_outside={handleClickOutside}
   on:keydown={onKeyDown}
   class="w-full lg:w-auto"

--- a/src/lib/components/hoc/modal.svelte
+++ b/src/lib/components/hoc/modal.svelte
@@ -103,6 +103,8 @@
         class:medium-width={width === "medium"}
         class:min-w-[80vw]={!width}
         class:overflow-y-auto={overflow}
+        on:click|stopPropagation
+        on:keypress|stopPropagation
       >
         <div class:mb-s24={!hideTitle} class:float-right={hideTitle}>
           <div class="flex justify-between">

--- a/src/lib/components/hoc/modal.svelte
+++ b/src/lib/components/hoc/modal.svelte
@@ -83,7 +83,13 @@
     <div
       id="background"
       class="flex items-center justify-center"
+      role="presentation"
       on:click={handleClose}
+      on:keypress={(event) => {
+        if (event.code === "Escape") {
+          handleClose();
+        }
+      }}
     >
       <div
         id="modal"
@@ -97,7 +103,6 @@
         class:medium-width={width === "medium"}
         class:min-w-[80vw]={!width}
         class:overflow-y-auto={overflow}
-        on:click|stopPropagation
       >
         <div class:mb-s24={!hideTitle} class:float-right={hideTitle}>
           <div class="flex justify-between">

--- a/src/lib/components/inputs/obsolete/select-options.svelte
+++ b/src/lib/components/inputs/obsolete/select-options.svelte
@@ -22,9 +22,16 @@
   <div
     class="option flex min-h-[36px] w-full cursor-pointer items-center justify-between p-s6 text-gray-dark {extraClass}"
     role="option"
+    aria-selected={selected}
     id={option.value}
     class:hover={option.value === selectedOption?.value}
     class:selected
+    tabindex="0"
+    on:keypress={(event) => {
+      if (event.code === "Enter") {
+        updateValue(option.value);
+      }
+    }}
     on:click|stopPropagation={() => updateValue(option.value)}
     on:mouseenter={() => setAsSelected(option.value)}
     on:mouseleave={() => setAsSelected(null)}
@@ -38,3 +45,9 @@
     </span>
   </div>
 {/each}
+
+<style lang="postcss">
+  .hover {
+    @apply bg-magenta-10 text-magenta-cta;
+  }
+</style>

--- a/src/lib/components/specialized/services/service-state-update-select.svelte
+++ b/src/lib/components/specialized/services/service-state-update-select.svelte
@@ -74,6 +74,8 @@
   export let hideLabel = true;
   export let fullWidth = false;
 
+  $: availableOptions = getAvailableOptionsForStatus(service.status);
+
   // *** Accessibilité
   const uuid: string = randomId(); // Pour éviter les conflits d'id si le composant est présent plusieurs fois sur la page
   let isDropdownOpen = false;
@@ -190,7 +192,6 @@
 
   // *** Valeurs pour l'affichage
   $: currentStatusPresentation = SERVICE_STATUS_PRESENTATION[service.status];
-  $: availableOptions = getAvailableOptionsForStatus(service.status);
 </script>
 
 <div
@@ -236,7 +237,7 @@
   <div
     class:hidden={!isDropdownOpen}
     class:w-full={fullWidth}
-    class="absolute top-s48 right-s0 z-20 min-w-[150px] rounded border border-gray-00 bg-white py-s12 px-s12 shadow-md"
+    class="absolute right-s0 top-s48 z-20 min-w-[150px] rounded border border-gray-00 bg-white px-s12 py-s12 shadow-md"
     role="listbox"
     id={`listbox-values-${uuid}`}
     aria-labelledby={`button-label-${uuid}`}
@@ -249,6 +250,13 @@
           class:bg-service-red={selectedOption === option}
           on:mouseenter={() => setAsSelected(option, index)}
           role="option"
+          tabindex="0"
+          aria-selected="false"
+          on:keypress={(event) => {
+            if (event.code === "Enter") {
+              updateServiceStatus(option);
+            }
+          }}
           on:click={() => updateServiceStatus(option)}
         >
           <span class="mr-s8 h-s24 w-s24 fill-current text-service-red-dark">
@@ -265,6 +273,13 @@
             : 'bg-transparent'}"
           role="option"
           id={option}
+          aria-selected="false"
+          tabindex="0"
+          on:keypress={(event) => {
+            if (event.code === "Enter") {
+              updateServiceStatus(option);
+            }
+          }}
           on:mouseenter={() => setAsSelected(option, index)}
           on:click={() => updateServiceStatus(option)}
         >

--- a/src/routes/_index/sub-menu-dropdown.svelte
+++ b/src/routes/_index/sub-menu-dropdown.svelte
@@ -37,6 +37,7 @@
 <div
   class="relative {mobileDesign ? 'border-b border-gray-03' : ''}"
   use:clickOutside
+  role="presentation"
   on:click_outside={handleClickOutside}
   on:keydown={onKeyDown}
 >

--- a/src/routes/admin/copyable-text.svelte
+++ b/src/routes/admin/copyable-text.svelte
@@ -4,6 +4,13 @@
 
 <span
   class="cursor-pointer text-f10 text-gray-text-alt underline"
+  tabindex="0"
+  role="button"
+  on:keypress={(event) => {
+    if (event.code === "Enter") {
+      navigator.clipboard.writeText(text);
+    }
+  }}
   on:click={() => {
     navigator.clipboard.writeText(text);
   }}>copier</span

--- a/src/routes/admin/structures/structures-table.svelte
+++ b/src/routes/admin/structures/structures-table.svelte
@@ -23,11 +23,12 @@
   />
 {/if}
 
-<div class="flex  flex-col gap-s8">
+<div class="flex flex-col gap-s8">
   {#each filteredStructures as structure}
     <div
       class="flex flex-row gap-s16 rounded-md border border-gray-01 p-s16 shadow-xs"
       class:highlight={selectedStructureSlug === structure.slug}
+      role="presentation"
       on:mouseenter={() => (selectedStructureSlug = structure.slug)}
       on:mouseleave={() => (selectedStructureSlug = null)}
     >

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -63,20 +63,6 @@ const config = {
       return;
     }
 
-    // Désactivation des avertissements d'accessibilité, le temps de finir la migration Sveltekit
-    // TODO: les corriger au lieu de les masquer
-    const ignoredA11yWarnings = [
-      "a11y-interactive-supports-focus",
-      "a11y-click-events-have-key-events",
-      "a11y-label-has-associated-control",
-      "a11y-role-has-required-aria-props",
-      "a11y-no-static-element-interactions",
-      "a11y-no-noninteractive-element-interactions",
-    ];
-    if (ignoredA11yWarnings.includes(warning.code)) {
-      return;
-    }
-
     // Le RGAA impose l'utilisation de ces `role`
     // et ces avertissements n'ont donc pas lieu d'être
     if (warning.code === "a11y-no-redundant-roles") {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -63,6 +63,13 @@ const config = {
       return;
     }
 
+    // Désactivation des avertissements d'accessibilité, le temps de finir la migration Sveltekit
+    // TODO: les corriger au lieu de les masquer
+    const ignoredA11yWarnings = ["a11y-no-noninteractive-element-interactions"];
+    if (ignoredA11yWarnings.includes(warning.code)) {
+      return;
+    }
+
     // Le RGAA impose l'utilisation de ces `role`
     // et ces avertissements n'ont donc pas lieu d'être
     if (warning.code === "a11y-no-redundant-roles") {


### PR DESCRIPTION
https://trello.com/c/QttaTJyb/917-a11y-reactiver-et-corriger-les-avertissements-daccessibilit%C3%A9

Notes :
1 - un warning me fait de la résistance : celui de la modale qui sert à isoler les clics qui surviennent dans la modale… et évite sa fermeture. L'enlever ferme la modale à chaque clic et le garder génère le warning… 
2 - Les `div` qui servent pour un click_outside ont été mis en `role="presentation"` car, en soi, c'est pas des boutons 🙂
3 - dans `service-state-update-select.svelte`, le `aria-selected` est tout le temps à `false` car la dropdown ne contient le statut courant