### PR TITLE
Correction des filtres

### DIFF
--- a/src/routes/recherche/+page.svelte
+++ b/src/routes/recherche/+page.svelte
@@ -2,7 +2,7 @@
   import { tick } from "svelte";
 
   import { page } from "$app/stores";
-  import { goto } from "$app/navigation";
+
   import Breadcrumb from "$lib/components/display/breadcrumb.svelte";
   import Button from "$lib/components/display/button.svelte";
   import CenteredGrid from "$lib/components/display/centered-grid.svelte";
@@ -93,10 +93,12 @@
         $page.url.searchParams.delete(queryParam);
       }
     });
-    goto(`?${$page.url.searchParams.toString()}`, {
-      noScroll: true,
-      keepFocus: true,
-    });
+    // Utilisation de l'API History pour mettre à jour les paramètres d'URL sans recharger la page
+    window.history.replaceState(
+      history.state,
+      "",
+      `?${$page.url.searchParams.toString()}`
+    );
   }
 
   function hasOnlyNationalResults(services: ServiceSearchResult[]) {

--- a/src/routes/recherche/+page.svelte
+++ b/src/routes/recherche/+page.svelte
@@ -133,9 +133,9 @@
       ),
       cityCode: data.cityCode,
       cityLabel: data.cityLabel,
-      kinds: data.kindIds,
-      fees: data.feeConditions,
-      locationKinds: data.locationKinds,
+      kinds: filters.kinds.sort(),
+      fees: filters.feeConditions.sort(),
+      locationKinds: filters.locationKinds.sort(),
     });
     await refreshUserInfo();
     creatingAlert = false;
@@ -152,9 +152,9 @@
       cityCode: data.cityCode,
       cityLabel: data.cityLabel,
       label: undefined,
-      kindIds: data.kindIds,
-      feeConditions: data.feeConditions,
-      locationKinds: data.locationKinds,
+      kindIds: filters.kinds.sort(),
+      feeConditions: filters.feeConditions.sort(),
+      locationKinds: filters.locationKinds.sort(),
     });
 
     const userSavedSearches = $userInfo?.savedSearches || [];


### PR DESCRIPTION
Cette PR corrige les deux problèmes suivants :
- Les filtres n'étaient pas correctement pris en compte dans la création d'alertes ;
- Charger directement un lien de recherche causait la dé-sélection des filtres.