### PR TITLE
Page service : indexation désactivée pour les services DI

### DIFF
--- a/src/routes/(modeles-services)/services/[slug]/+page.ts
+++ b/src/routes/(modeles-services)/services/[slug]/+page.ts
@@ -25,6 +25,7 @@ export const load: PageLoad = async ({ url, params, parent }) => {
       service,
       servicesOptions: await getServicesOptions(),
       isDI: true,
+      noIndex: true,
     };
   }
 


### PR DESCRIPTION
D'un jour à l'autre, un service DI peut disparaître. On ne veut donc pas qu'ils soient indexés.