### PR TITLE
Liste des services: corrige comportement bouton Tout effacer

### DIFF
--- a/src/routes/structures/[slug]/services/list.svelte
+++ b/src/routes/structures/[slug]/services/list.svelte
@@ -198,6 +198,13 @@
     updateUrlQueryParams();
   }
 
+  function handleResetFilters() {
+    serviceStatus = undefined;
+    updateStatus = undefined;
+    servicesDisplayed = filterAndSortServices(structure.services);
+    updateUrlQueryParams();
+  }
+
   $: servicesDisplayed = filterAndSortServices(structure.services);
 </script>
 
@@ -271,10 +278,7 @@
         <button
           class:!text-magenta-cta={serviceStatus || updateStatus}
           class="text-gray-text-alt"
-          on:click={() => {
-            serviceStatus = undefined;
-            updateStatus = undefined;
-          }}
+          on:click={handleResetFilters}
         >
           Tout effacer
         </button>


### PR DESCRIPTION
Sur la vue `/structures/:slug/services`, le bouton _Tout effacer_ réinitialisait bien les sélecteurs mais pas le paramètre GET `update-status` et la liste des services affichés. Cette PR corrige ça.