### PR TITLE
HOTFIX: erreur à l'affichage des types pour certains services D·I

### DIFF
--- a/src/lib/components/specialized/services/display/service-key-informations.svelte
+++ b/src/lib/components/specialized/services/display/service-key-informations.svelte
@@ -21,7 +21,7 @@
   export let servicesOptions: ServicesOptions;
 
   // trier les types dans l'ordre d'affichage du formulaire
-  $: sortedServiceKindsDisplay = service.kindsDisplay.sort((a, b) =>
+  $: sortedServiceKindsDisplay = service.kindsDisplay?.sort((a, b) =>
     a.localeCompare(b)
   );
 </script>


### PR DESCRIPTION
Certains services D·I ne disposent pas de la donnée, et incorrectement
bordé côté DORA.
