### PR TITLE
[HOTFIX] Le formulaire d'orientation ne doit pas être public

### DIFF
--- a/src/routes/(modeles-services)/services/[slug]/orienter/+page.ts
+++ b/src/routes/(modeles-services)/services/[slug]/orienter/+page.ts
@@ -1,5 +1,14 @@
+import { error } from "@sveltejs/kit";
+
 export const load = async ({ parent }) => {
   const data = await parent();
+  const { service } = data;
+
+  // on ne doit pas pouvoir accèder à cette page
+  // si le service n'est pas orientable
+  if (!service.isOrientable) {
+    error(400, "Service non-orientable");
+  }
 
   return {
     ...data,


### PR DESCRIPTION
Les règles d'orientation fixées par le back-end sont correctes : les
services FT ne sont *jamais* orientables.

Par contre, l'accès direct au formulaire d'orientation était possible
pour les services non-orientables.
