### PR TITLE
SearchResult: affiche distance moins de 1 km

### DIFF
--- a/src/routes/recherche/search-result.svelte
+++ b/src/routes/recherche/search-result.svelte
@@ -116,11 +116,15 @@
             {result.address1}{#if result.address2}, {result.address2}{/if},
             {result.postalCode}&nbsp;{result.city}
           </div>
-          {#if result.distance > 0}
+          {#if typeof result.distance === "number"}
             <div class="tag">
-              à&nbsp;{result.distance < 10
-                ? Math.round(result.distance * 10) / 10
-                : Math.round(result.distance)}&nbsp;km
+              {#if result.distance === 0}
+                &lt; 1 km
+              {:else}
+                à&nbsp;{result.distance < 10
+                  ? Math.round(result.distance * 10) / 10
+                  : Math.round(result.distance)} km
+              {/if}
             </div>
           {/if}
         {/if}


### PR DESCRIPTION
Les services DI renvoient une distance entière en km. Elle peut être de 0. Dans ce cas, on affiche _< 1 km_ au lieu de ne pas afficher la distance du tout.

J'en profite pour utiliser des espaces fines insécables là où il faut.