### PR TITLE
SearchResult : n'affiche pas la distance < 1 km lorsqu'il s'agit d'un servce DORA

### DIFF
--- a/src/routes/recherche/search-result.svelte
+++ b/src/routes/recherche/search-result.svelte
@@ -116,7 +116,9 @@
             {result.address1}{#if result.address2}, {result.address2}{/if},
             {result.postalCode}&nbsp;{result.city}
           </div>
-          {#if typeof result.distance === "number"}
+          <!-- On n'affiche pas la distance lorsqu'elle n'est pas fournie ou
+               lorsqu'il s'agit d'un service DORA et que la distance est de 0. -->
+          {#if typeof result.distance === "number" && !(!isDI && result.distance === 0)}
             <div class="tag">
               {#if result.distance === 0}
                 &lt; 1 km


### PR DESCRIPTION
On n'affiche pas la distance lorsqu'il s'agit d'un service DORA et que la distance est de 0 (car cela signifie que le service est dans la ville de recherche).