### PR TITLE
Corrections modalités d'orientation

### DIFF
--- a/src/lib/components/display/linkify.svelte
+++ b/src/lib/components/display/linkify.svelte
@@ -1,18 +1,16 @@
 <script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
   import { externalLinkIcon } from "$lib/icons";
-  import type { Model, Service } from "$lib/types";
-  import { trackMobilisation } from "$lib/utils/stats";
-  import { page } from "$app/stores";
 
   export let text: string;
-  export let trackMobilisationOnLinkClick:
-    | { service: Service | Model; isDI: boolean }
-    | undefined = undefined;
 
   type Parts = Array<
     | { type: "link"; value: string; display: string; key: number }
     | { type: "text"; value: string; key: number }
   >;
+
+  const dispatch = createEventDispatcher<{ linkClick: { url: string } }>();
 
   function linkify(string: string) {
     const urlRegex = /(https?:\/\/[^\s]+|mailto:[^\s]+|tel:[^\s]+)/g;
@@ -35,11 +33,8 @@
     }) as Parts;
   }
 
-  function handleLinkClick() {
-    if (trackMobilisationOnLinkClick) {
-      const { service, isDI } = trackMobilisationOnLinkClick;
-      trackMobilisation(service, $page.url, isDI);
-    }
+  function handleLinkClick(url: string) {
+    dispatch("linkClick", { url });
   }
 
   $: parts = linkify(text);
@@ -49,7 +44,7 @@
   {#if part.type === "link"}
     <a
       href={part.value}
-      on:click={handleLinkClick}
+      on:click={() => handleLinkClick(part.value)}
       target="_blank"
       rel="noopener ugc"
       class="text-magenta-cta underline"

--- a/src/lib/utils/stats.ts
+++ b/src/lib/utils/stats.ts
@@ -76,7 +76,8 @@ export async function trackMobilisation<T extends boolean>(
   service: ServiceType<T>,
   url: URL,
   isDI: T,
-  searchId?: number
+  searchId?: number,
+  externalLink?: string
 ) {
   if (browser) {
     if (isDI) {
@@ -91,12 +92,14 @@ export async function trackMobilisation<T extends boolean>(
         diCategories: diService.categories || [],
         diSubcategories: diService.subcategories || [],
         searchId: searchId || url.searchParams.get("searchId"),
+        externalLink,
       });
     } else {
       const doraService = service as ServiceType<false>;
       await logAnalyticsEvent("mobilisation", url.pathname, {
         service: doraService.slug,
         searchId: searchId || url.searchParams.get("searchId"),
+        externalLink,
       });
     }
   }

--- a/src/routes/(modeles-services)/_common/display/service-body.svelte
+++ b/src/routes/(modeles-services)/_common/display/service-body.svelte
@@ -21,9 +21,19 @@
   // Utilisé pour prévenir le tracking multiple
   let mobilisationTracked = false;
 
-  function handleTrackMobilisation() {
+  function handleTrackMobilisation(
+    event: CustomEvent<{ externalUrl?: string }>
+  ) {
     if (!mobilisationTracked) {
-      trackMobilisation(service, $page.url, isDI);
+      const searchIdStr = $page.url.searchParams.get("searchId");
+      const searchId = searchIdStr ? parseInt(searchIdStr) : undefined;
+      trackMobilisation(
+        service,
+        $page.url,
+        isDI,
+        searchId,
+        event.detail.externalUrl
+      );
       mobilisationTracked = true;
     }
   }

--- a/src/routes/(modeles-services)/_common/display/service-mobilisation.svelte
+++ b/src/routes/(modeles-services)/_common/display/service-mobilisation.svelte
@@ -23,7 +23,9 @@
     "completer-le-formulaire-dadhesion"
   );
 
-  const dispatch = createEventDispatcher();
+  const dispatch = createEventDispatcher<{
+    trackMobilisation: { externalUrl?: string };
+  }>();
 
   let sharingModalIsOpen = false;
   let contactBoxOpen = false;
@@ -39,7 +41,7 @@
     }
     contactBoxOpen = true;
     // on tracke comme une MER si les contacts du service sont publics
-    dispatch("trackMobilisation");
+    dispatch("trackMobilisation", {});
   }
 
   function handleOrientationClick() {
@@ -47,7 +49,7 @@
       showContact();
     } else {
       if ($token) {
-        dispatch("trackMobilisation");
+        dispatch("trackMobilisation", {});
       }
       const searchId = $page.url.searchParams.get("searchId");
       const searchFragment = searchId ? `?searchId=${searchId}` : "";
@@ -59,8 +61,8 @@
     }
   }
 
-  function handleExternalFormClick() {
-    dispatch("trackMobilisation");
+  function handleExternalFormClick(externalUrl: string) {
+    dispatch("trackMobilisation", { externalUrl });
   }
 
   function handleShareClick() {
@@ -92,7 +94,8 @@
 
   {#if hasExternalForm}
     <LinkButton
-      on:click={handleExternalFormClick}
+      on:click={() =>
+        handleExternalFormClick(service.coachOrientationModesExternalFormLink)}
       to={service.coachOrientationModesExternalFormLink}
       extraClass="bg-white !text-france-blue hover:!text-white text-center !whitespace-normal text-center"
       label={service.coachOrientationModesExternalFormLinkText ||

--- a/src/routes/(modeles-services)/_common/display/service-mobilize.svelte
+++ b/src/routes/(modeles-services)/_common/display/service-mobilize.svelte
@@ -54,19 +54,21 @@
   const searchFragment = searchId ? `?searchId=${searchId}` : "";
   const orientationFormUrl = `/services/${isDI ? "di--" : ""}${service.slug}/orienter${searchFragment}`;
 
-  const dispatch = createEventDispatcher();
+  const dispatch = createEventDispatcher<{
+    trackMobilisation: { externalUrl?: string };
+  }>();
 
   let isContactInfoForProfessionalShown = false;
   let isContactInfoForIndividualShown = false;
 
   function trackMobilisationIfSignedIn() {
     if ($token) {
-      dispatch("trackMobilisation");
+      dispatch("trackMobilisation", {});
     }
   }
 
-  function trackMobilisationUnconditionally() {
-    dispatch("trackMobilisation");
+  function trackMobilisationUnconditionally(externalUrl: string) {
+    dispatch("trackMobilisation", { externalUrl });
   }
 
   function showContactInfoForProfessional() {
@@ -78,12 +80,12 @@
       );
       return;
     }
-    dispatch("trackMobilisation");
+    dispatch("trackMobilisation", {});
     isContactInfoForProfessionalShown = true;
   }
 
   function showContactInfoForIndividual() {
-    dispatch("trackMobilisation");
+    dispatch("trackMobilisation", {});
     isContactInfoForIndividualShown = true;
   }
 
@@ -156,7 +158,10 @@
               <a
                 href={service.coachOrientationModesExternalFormLink}
                 target="_blank"
-                on:click={trackMobilisationUnconditionally}
+                on:click={() =>
+                  trackMobilisationUnconditionally(
+                    service.coachOrientationModesExternalFormLink
+                  )}
                 class="text-magenta-cta underline"
                 >{service.coachOrientationModesExternalFormLinkText ||
                   "Orienter votre bénéficiaire"}
@@ -214,7 +219,10 @@
               <a
                 href={service.beneficiariesAccessModesExternalFormLink}
                 target="_blank"
-                on:click={trackMobilisationUnconditionally}
+                on:click={() =>
+                  trackMobilisationUnconditionally(
+                    service.beneficiariesAccessModesExternalFormLink
+                  )}
                 class="text-magenta-cta underline"
                 >{service.beneficiariesAccessModesExternalFormLinkText ||
                   "Faire une demande"}

--- a/src/routes/(modeles-services)/_common/display/service-mobilize.svelte
+++ b/src/routes/(modeles-services)/_common/display/service-mobilize.svelte
@@ -167,10 +167,8 @@
             {:else if modeValue === "autre"}
               <Linkify
                 text={service.coachOrientationModesOther}
-                trackMobilisationOnLinkClick={{
-                  service,
-                  isDI,
-                }}
+                on:linkClick={(event) =>
+                  trackMobilisationUnconditionally(event.detail.url)}
               />
             {:else}
               {modeDisplay}
@@ -229,10 +227,8 @@
             {:else if modeValue === "autre"}
               <Linkify
                 text={service.beneficiariesAccessModesOther}
-                trackMobilisationOnLinkClick={{
-                  service,
-                  isDI,
-                }}
+                on:linkClick={(event) =>
+                  trackMobilisationUnconditionally(event.detail.url)}
               />
             {:else}
               {modeDisplay}

--- a/src/routes/(modeles-services)/_common/display/service-mobilize.svelte
+++ b/src/routes/(modeles-services)/_common/display/service-mobilize.svelte
@@ -87,6 +87,11 @@
     isContactInfoForIndividualShown = true;
   }
 
+  $: contactInfoForIndividual =
+    service.isContactInfoPublic &&
+    service.beneficiariesAccessModes.some((mode) =>
+      ["envoyer-un-mail", "telephoner"].includes(mode)
+    );
   $: contactInfoForIndividualAddress = [
     service.structureInfo.address1,
     service.structureInfo.address2,
@@ -237,7 +242,7 @@
           <li>Non renseigné</li>
         {/each}
       </ul>
-      {#if contactInfoForIndividualPhone || contactInfoForIndividualEmail}
+      {#if contactInfoForIndividual}
         <div class="rounded-ml border border-gray-02 p-s24 shadow-sm">
           {#if isContactInfoForIndividualShown}
             <h5>{service.structureInfo.name}</h5>

--- a/src/routes/(modeles-services)/_common/fields-modalities-beneficiary.svelte
+++ b/src/routes/(modeles-services)/_common/fields-modalities-beneficiary.svelte
@@ -17,18 +17,23 @@
   export let servicesOptions: ServicesOptions;
 
   let beneficiariesAccessModesFocusValue: string | undefined = undefined;
+  let preventUpdateExternalFormFields = true;
 
-  $: {
-    // Suppression du lien vers le formulaire externe et de son intitulé
-    // lorsque la case du formulaire externe est décochée.
-    if (
-      !service.beneficiariesAccessModes.includes(
-        "completer-le-formulaire-dadhesion"
-      )
-    ) {
-      service.beneficiariesAccessModesExternalFormLink = "";
-      service.beneficiariesAccessModesExternalFormLinkText = "";
+  function updateExternalFormFields(text: string) {
+    if (preventUpdateExternalFormFields) {
+      // Don't reset fields on first load
+      preventUpdateExternalFormFields = false;
+      return;
     }
+    service.beneficiariesAccessModesExternalFormLink = "";
+    service.beneficiariesAccessModesExternalFormLinkText = text;
+  }
+
+  $: externalFormToggle = service.beneficiariesAccessModes.includes(
+    "completer-le-formulaire-dadhesion"
+  );
+  $: {
+    updateExternalFormFields(externalFormToggle ? "Faire une demande" : "");
   }
 
   $: servicesOptions.beneficiariesAccessModes.sort(
@@ -66,7 +71,6 @@
             <BasicInputField
               id="beneficiariesAccessModesExternalFormLinkText"
               description="Par exemple : Faire une demande, Faire une simulation, Prendre rendez-vous, etc."
-              placeholder="Faire une demande"
               vertical
               bind:value={service.beneficiariesAccessModesExternalFormLinkText}
             />

--- a/src/routes/(modeles-services)/_common/fields-modalities-beneficiary.svelte
+++ b/src/routes/(modeles-services)/_common/fields-modalities-beneficiary.svelte
@@ -21,7 +21,7 @@
 
   function updateExternalFormFields(text: string) {
     if (preventUpdateExternalFormFields) {
-      // Don't reset fields on first load
+      // Pas de réinitialisation des champs au premier chargement
       preventUpdateExternalFormFields = false;
       return;
     }

--- a/src/routes/(modeles-services)/_common/fields-modalities-coach.svelte
+++ b/src/routes/(modeles-services)/_common/fields-modalities-coach.svelte
@@ -17,18 +17,25 @@
   export let servicesOptions: ServicesOptions;
 
   let coachOrientationModesFocusValue: string | undefined = undefined;
+  let preventUpdateExternalFormFields = true;
 
-  $: {
-    // Suppression du lien vers le formulaire externe et de son intitulé
-    // lorsque la case du formulaire externe est décochée.
-    if (
-      !service.coachOrientationModes.includes(
-        "completer-le-formulaire-dadhesion"
-      )
-    ) {
-      service.coachOrientationModesExternalFormLink = "";
-      service.coachOrientationModesExternalFormLinkText = "";
+  function updateExternalFormFields(text: string) {
+    if (preventUpdateExternalFormFields) {
+      // Don't reset fields on first load
+      preventUpdateExternalFormFields = false;
+      return;
     }
+    service.coachOrientationModesExternalFormLink = "";
+    service.coachOrientationModesExternalFormLinkText = text;
+  }
+
+  $: externalFormToggle = service.coachOrientationModes.includes(
+    "completer-le-formulaire-dadhesion"
+  );
+  $: {
+    updateExternalFormFields(
+      externalFormToggle ? "Orienter votre bénéficiaire" : ""
+    );
   }
 
   $: servicesOptions.coachOrientationModes.sort(
@@ -66,7 +73,6 @@
             <BasicInputField
               id="coachOrientationModesExternalFormLinkText"
               description="Par exemple : Orienter votre bénéficiaire, Faire une simulation, Prendre rendez-vous, etc."
-              placeholder="Orienter votre bénéficiaire"
               vertical
               bind:value={service.coachOrientationModesExternalFormLinkText}
             />

--- a/src/routes/(modeles-services)/_common/fields-modalities-coach.svelte
+++ b/src/routes/(modeles-services)/_common/fields-modalities-coach.svelte
@@ -21,7 +21,7 @@
 
   function updateExternalFormFields(text: string) {
     if (preventUpdateExternalFormFields) {
-      // Don't reset fields on first load
+      // Pas de réinitialisation des champs au premier chargement
       preventUpdateExternalFormFields = false;
       return;
     }


### PR DESCRIPTION
- Texte de lien par défaut au lieu d'un placeholder pour le formulaire externe ;
- Affiche le bouton de coordonnées si les infos de contact sont publiques et si il y a une modalité bénéficiaire `telephoner` ou `envoyer-un-mail` ;
- Modification de Linkify pour qu'il émette un événement linkClick au lieu de prendre une prop `trackMobilisationOnLinkClick` ;
- Ajout du lien externe dans les événements de mobilisation.