### PR TITLE
Expérimentation Matomo : bouton Orienter votre bénéficiaire

### DIFF
--- a/src/lib/utils/matomo.ts
+++ b/src/lib/utils/matomo.ts
@@ -1,0 +1,44 @@
+declare global {
+  const Matomo: any;
+  const Piwik: any;
+  interface Window {
+    matomoAbTestingAsyncInit: any;
+  }
+}
+
+interface MatomoTarget {
+  attribute: string;
+  inverted: string;
+  type: string;
+  value: string;
+}
+
+interface MatomoVariation {
+  name: string;
+  activate: (event: unknown) => void;
+}
+
+interface MatomoExperiment {
+  name: string;
+  includedTargets: MatomoTarget[];
+  excludedTargets: MatomoTarget[];
+  variations: MatomoVariation[];
+}
+
+export function registerMatomoExperiment(experiment: MatomoExperiment) {
+  function createExperiment() {
+    const Experiment = Matomo.AbTesting.Experiment;
+
+    const myExperiment = new Experiment(experiment);
+
+    myExperiment.getActivatedVariationName();
+  }
+
+  if ("object" === typeof Piwik && "object" === typeof Matomo.AbTesting) {
+    // if matomo.js was embedded before this code
+    createExperiment();
+  } else {
+    // if matomo.js is loaded after this code
+    window.matomoAbTestingAsyncInit = createExperiment;
+  }
+}

--- a/src/routes/recherche/search-result.svelte
+++ b/src/routes/recherche/search-result.svelte
@@ -3,10 +3,12 @@
   import { page } from "$app/stores";
 
   import Button from "$lib/components/display/button.svelte";
+  import LinkButton from "$lib/components/display/link-button.svelte";
   import Bookmarkable from "$lib/components/hoc/bookmarkable.svelte";
   import FavoriteIcon from "$lib/components/specialized/favorite-icon.svelte";
   import type { ServiceSearchResult } from "$lib/types";
   import { token } from "$lib/utils/auth";
+  import { registerMatomoExperiment } from "$lib/utils/matomo";
   import { trackMobilisation } from "$lib/utils/stats";
 
   export let id: string;
@@ -41,6 +43,8 @@
     }
   }
 
+  let redirectToOrientationForm = true;
+
   function handleOrientationClick() {
     if ($token) {
       const service = isDI
@@ -58,6 +62,22 @@
       : "";
     goto(`/services/${slug}/orienter?${queryString}`);
   }
+
+  registerMatomoExperiment({
+    name: "CTA-Orienter",
+    includedTargets: [
+      { attribute: "url", inverted: "0", type: "any", value: "" },
+    ],
+    excludedTargets: [],
+    variations: [
+      {
+        name: "Fiche-service",
+        activate: function () {
+          redirectToOrientationForm = false;
+        },
+      },
+    ],
+  });
 </script>
 
 <Bookmarkable slug={result.slug} {isDI} let:onBookmark let:isBookmarked>
@@ -141,12 +161,21 @@
               class="text-magenta-cta underline">Voir la fiche détaillée</a
             >
             {#if result.isOrientable && result.coachOrientationModes?.includes("formulaire-dora")}
-              <Button
-                on:click={handleOrientationClick}
-                label="Orienter votre bénéficiaire"
-                secondary
-                small
-              />
+              {#if redirectToOrientationForm}
+                <Button
+                  on:click={handleOrientationClick}
+                  label="Orienter votre bénéficiaire"
+                  secondary
+                  small
+                />
+              {:else}
+                <LinkButton
+                  to={servicePagePath}
+                  label="Orienter votre bénéficiaire"
+                  secondary
+                  small
+                />
+              {/if}
             {/if}
           </div>
         </div>


### PR DESCRIPTION
- Ajout d'une fonction utilitaire `registerMatomoExperiment()` et des types associés ;
- Ajout du code pour l'expérimentation `CTA-Orienter.`

Si la variation active est `Fiche-service`, alors le bouton est un lien vers la fiche service. Sinon, le bouton redirige vers le formulaire d'orientation.