### PR TITLE
Modalité orientation / choix par éditeur : masquer le formulaire DORA pour les Agences FT

### DIFF
--- a/src/routes/(modeles-services)/services/service-edition-form.svelte
+++ b/src/routes/(modeles-services)/services/service-edition-form.svelte
@@ -118,6 +118,15 @@
   $: currentSchema = service.useInclusionNumeriqueScheme
     ? inclusionNumeriqueSchema
     : serviceSchema;
+
+  $: {
+    if (structure.noDoraForm) {
+      servicesOptions.coachOrientationModes =
+        servicesOptions.coachOrientationModes.filter(
+          (mode) => mode.value !== "formulaire-dora"
+        );
+    }
+  }
 </script>
 
 <FormErrors />


### PR DESCRIPTION
Le formulaire d'édition de service (utilisé en création et modification) ne propose pas la modalité _Via le formulaire DORA_ lorsqu'il est désactivé au niveau de la structure.