### PR TITLE
[Fix] Un défaut de rendu du composant ServiceMobilize empêchait le rendu de toute la page service

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,3 +12,5 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+.history

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 .cache_ggshield
 .idea
 .vscode
+.history

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,5 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+.history

--- a/src/routes/(modeles-services)/_common/display/service-mobilize.svelte
+++ b/src/routes/(modeles-services)/_common/display/service-mobilize.svelte
@@ -91,7 +91,7 @@
 
   $: contactInfoForIndividual =
     service.isContactInfoPublic ||
-    service.beneficiariesAccessModes.some((mode) =>
+    (service.beneficiariesAccessModes ?? []).some((mode) =>
       ["envoyer-un-mail", "telephoner"].includes(mode)
     );
   $: contactInfoForIndividualAddress = [
@@ -107,7 +107,9 @@
   $: contactInfoForIndividualEmail =
     service.contactEmail || service.structureInfo.email;
 
-  $: coachOrientationModesValueAndDisplay = service.coachOrientationModes
+  $: coachOrientationModesValueAndDisplay = (
+    service.coachOrientationModes ?? []
+  )
     .map((val, index) => [val, service.coachOrientationModesDisplay[index]])
     .sort(
       (a, b) =>
@@ -115,7 +117,9 @@
         orderedCoachOrientationModeValues[b[0]]
     );
 
-  $: beneficiariesAccessModesValueAndDisplay = service.beneficiariesAccessModes
+  $: beneficiariesAccessModesValueAndDisplay = (
+    service.beneficiariesAccessModes ?? []
+  )
     .map((val, index) => [val, service.beneficiariesAccessModesDisplay[index]])
     .sort(
       (a, b) =>


### PR DESCRIPTION
### 🍣 Problème

Depuis récemment, quand on consulte la page d'un service ne proposant pas de `beneficiariesAccessModes` ou de `coachOrientationModes`, alors la page ne s'affiche pas et une "erreur inattendue" est indiquée.

Ex : [fiche service de monenfant.fr ](https://dora.inclusion.beta.gouv.fr/services/di--monenfant--12859394)

### 🦄 Solution

Le problème se situe dans le composant `<ServiceMobilize/>`.

Cette PR ajoute des vérifications d'existence de l'une ou l'autre propriété (_fallback_ vers tableau vide pour la boucle).