### PR TITLE
[Fix] Correction de la gestion des labels nationaux restreints

### DIFF
--- a/src/lib/components/forms/fields/multi-select-field.svelte
+++ b/src/lib/components/forms/fields/multi-select-field.svelte
@@ -21,6 +21,7 @@
   export let sort = false;
   export let onChange: ((newValues: string[]) => void) | undefined = undefined;
   export let placeholderMulti = "Choisir";
+  export let fixedItemsValues: string[] = [];
 
   // Proxy vers le FieldWrapper
   export let description = "";
@@ -48,6 +49,7 @@
       on:blur={onBlur}
       {id}
       {choices}
+      {fixedItemsValues}
       {onChange}
       {sort}
       {placeholder}

--- a/src/lib/components/inputs/select/select.svelte
+++ b/src/lib/components/inputs/select/select.svelte
@@ -4,6 +4,7 @@
   export let id: string;
   export let choices: { value: string | number; label: string }[] | undefined =
     undefined;
+  export let fixedItemsValues: string[] = [];
   export let sort = false;
   export let value: string | number | string[] | number[] | undefined =
     undefined;
@@ -51,6 +52,7 @@
   {minCharactersToSearch}
   {onChange}
   bind:items={choices}
+  {fixedItemsValues}
   {initialValue}
   {disabled}
   {readonly}

--- a/src/lib/components/inputs/select/simple-autocomplete.svelte
+++ b/src/lib/components/inputs/select/simple-autocomplete.svelte
@@ -10,8 +10,11 @@
   import { clickOutside } from "$lib/utils/misc";
   import { formatErrors } from "$lib/validation/validation";
 
-  // the list of items  the user can select from
+  // the list of items the user can select from
   export let items = [];
+
+  // a list of items values that the user can not remove (ex: structure national labels)
+  export let fixedItemsValues: string[] = [];
 
   // function to use to get all items (alternative to providing items)
   export let searchFunction = null;
@@ -151,6 +154,13 @@
     return item?.label;
   }
 
+  function isFixedItem(val) {
+    const fixedItemValue = fixedItemsValues.find(
+      (fixedValue) => fixedValue === val
+    );
+    return !!fixedItemValue;
+  }
+
   function onValueChanged() {
     if (value !== undefined) {
       if (multiple) {
@@ -190,19 +200,28 @@
   }
 
   function prepareListItems() {
-    if (!Array.isArray(items)) {
+    if (!Array.isArray(items) || items.length === 0) {
       items = [];
+      listItems = [];
+      return;
     }
 
-    const length = items ? items.length : 0;
-    listItems = new Array(length);
-
-    if (length > 0) {
-      items.forEach((item, i) => {
-        const listItem = getListItem(item);
-        listItems[i] = listItem;
-      });
+    let selectableItems;
+    if (fixedItemsValues && fixedItemsValues.length > 0) {
+      selectableItems = items.filter(
+        (item) =>
+          !fixedItemsValues.find((fixedValue) => fixedValue === item.value)
+      );
+    } else {
+      selectableItems = items;
     }
+
+    listItems = new Array(selectableItems.length);
+
+    selectableItems.forEach((item, i) => {
+      const listItem = getListItem(item);
+      listItems[i] = listItem;
+    });
   }
 
   function getListItem(item) {
@@ -839,7 +858,7 @@
       >
         {getLabelForValue(tagItem)}
 
-        {#if !disabled && !readonly}
+        {#if !disabled && !readonly && !isFixedItem(tagItem)}
           <button
             class="tag-delete"
             on:click|preventDefault={unselectItem(tagItem)}

--- a/src/routes/structures/[slug]/editer/structure-edition-fields.svelte
+++ b/src/routes/structures/[slug]/editer/structure-edition-fields.svelte
@@ -14,16 +14,10 @@
   export let structure: Structure;
   export let structuresOptions: StructuresOptions;
 
-  // StructureOptions contient un champ `restrictedNationalsLabel` permettant
-  // de ne pas afficher certains labels qui ne sont pas modifiable par l'utilisateur.
-  const filteredNationalLabels = structuresOptions.nationalLabels.filter(
-    // J'avais rajouté un type pour permettre de filtrer sans avoir à faire ça :(
-    // preneur d'une solution plus propre / concise.
-    (elt) =>
-      !structuresOptions.restrictedNationalLabels.find(
-        (restricted: NationalLabel) => elt.value === restricted.value
-      )
-  );
+  const fixedNationalLabelValues: string[] =
+    structuresOptions.restrictedNationalLabels.map(
+      (restricted: NationalLabel) => restricted.value
+    );
 
   function getAccessLibreUrl(struct: Structure) {
     const department = getDepartmentFromCityCode(struct.cityCode);
@@ -117,7 +111,8 @@
 <MultiSelectField
   id="nationalLabels"
   bind:value={structure.nationalLabels}
-  choices={filteredNationalLabels}
+  choices={structuresOptions.nationalLabels}
+  fixedItemsValues={fixedNationalLabelValues}
   description="Indiquez si la structure fait partie d’un ou plusieurs réseaux nationaux"
   placeholder="Choisissez…"
   placeholderMulti="Choisissez…"


### PR DESCRIPTION
### 🍣 Contexte / problème

Des bugs ont été constatés lors de la recette du ticket : 
https://trello.com/c/CVlvfhYh/153-ajouter-label-ft-sur-structures

### 🦄 Solution

La gestion de ces options de libellés est assez particulière et avancée.

La solution proposée par cette PR consiste à ajouter une propriété – `fixedItemValues` – au composant de sélection `<SimpleAutocomplete/>` pour gérer des "options fixes".

Une option fixe ne peut être ni sélectionnée, ni retirée (ex : label "France Travail" pour une agence France Travail)
